### PR TITLE
feat: scaffold GUWT simulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# Playground
+# GUWT Simulator
+
+Interactive Grand Unified Wave Theory simulator built with Vite, React and TypeScript. The app models a scalar field representing a fabric of space with a scale dependent coupling.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Testing
+
+```bash
+npm test
+```
+
+This project includes a simple CPU solver and Web Worker; WebGL renderer is stubbed.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,13 @@
+import js from '@eslint/js';
+import ts from 'typescript-eslint';
+import react from 'eslint-plugin-react';
+import prettier from 'eslint-plugin-prettier';
+import configPrettier from 'eslint-config-prettier';
+
+export default ts.config({
+  extends: [js.configs.recommended, react.configs.recommended, configPrettier],
+  plugins: { prettier },
+  languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+  files: ['**/*.{ts,tsx}'],
+  rules: { 'prettier/prettier': 'error' },
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GUWT Simulator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "guwt-simulator",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest",
+    "lint": "eslint . --ext .ts,.tsx",
+    "format": "prettier --write .",
+    "typecheck": "tsc --noEmit",
+    "deploy": "gh-pages -d dist"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "vitest": "^0.34.0",
+    "eslint": "^8.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint-plugin-react": "^7.0.0",
+    "prettier": "^3.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "gh-pages": "^6.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect } from 'react';
+import { useStore } from './sim/store';
+import ControlPanel from './components/ControlPanel';
+import Canvas2D from './components/Canvas2D';
+import DiagnosticsPanel from './components/DiagnosticsPanel';
+
+const App: React.FC = () => {
+  const init = useStore((s) => s.init);
+  useEffect(() => {
+    init();
+  }, [init]);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <ControlPanel />
+      <div style={{ flex: 1, display: 'flex' }}>
+        <Canvas2D />
+        <DiagnosticsPanel />
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/Canvas2D.tsx
+++ b/src/components/Canvas2D.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useRef } from 'react';
+import { useStore } from '../sim/store';
+
+const Canvas2D: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const frame = useStore((s) => s.frame);
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = frame.width;
+    canvas.height = frame.height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const img = new ImageData(frame.width, frame.height);
+    img.data.set(frame.pixels);
+    ctx.putImageData(img, 0, 0);
+  }, [frame]);
+  return <canvas ref={canvasRef} style={{ flex: 1 }} />;
+};
+
+export default Canvas2D;

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import ModeSwitch from './ModeSwitch';
+import PresetBadge from './PresetBadge';
+import { useStore } from '../sim/store';
+
+const ControlPanel: React.FC = () => {
+  const running = useStore((s) => s.running);
+  const start = useStore((s) => s.start);
+  const stop = useStore((s) => s.stop);
+  const preset = useStore((s) => s.preset);
+  const applyPreset = useStore((s) => s.applyPreset);
+
+  return (
+    <div style={{ display: 'flex', gap: '0.5rem', padding: '0.5rem', background: '#222' }}>
+      <ModeSwitch />
+      <button onClick={running ? stop : start}>{running ? 'Pause' : 'Play'}</button>
+      <select value={preset} onChange={(e) => applyPreset(e.target.value as any)}>
+        <option value="kepler">Kepler</option>
+        <option value="atomic">Atomic-ish</option>
+        <option value="strong">Strong-ish</option>
+        <option value="custom">Custom</option>
+      </select>
+      <PresetBadge />
+    </div>
+  );
+};
+
+export default ControlPanel;

--- a/src/components/DiagnosticsPanel.tsx
+++ b/src/components/DiagnosticsPanel.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useStore } from '../sim/store';
+
+const DiagnosticsPanel: React.FC = () => {
+  const diagnostics = useStore((s) => s.diagnostics);
+  return (
+    <div style={{ width: '200px', padding: '0.5rem', background: '#222' }}>
+      <div>FPS: {diagnostics.fps.toFixed(1)}</div>
+      <div>Energy: {diagnostics.energy.toFixed(3)}</div>
+    </div>
+  );
+};
+
+export default DiagnosticsPanel;

--- a/src/components/GLRenderer.tsx
+++ b/src/components/GLRenderer.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const GLRenderer: React.FC = () => {
+  return <canvas style={{ flex: 1 }} />;
+};
+
+export default GLRenderer;

--- a/src/components/ModeSwitch.tsx
+++ b/src/components/ModeSwitch.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useStore } from '../sim/store';
+
+const ModeSwitch: React.FC = () => {
+  const mode = useStore((s) => s.mode);
+  const setMode = useStore((s) => s.setMode);
+  return (
+    <select value={mode} onChange={(e) => setMode(e.target.value as any)}>
+      <option value="pair">Pairwise</option>
+      <option value="field">Field</option>
+    </select>
+  );
+};
+
+export default ModeSwitch;

--- a/src/components/PresetBadge.tsx
+++ b/src/components/PresetBadge.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { useStore } from '../sim/store';
+
+const PresetBadge: React.FC = () => {
+  const preset = useStore((s) => s.preset);
+  return <span style={{ marginLeft: 'auto' }}>{preset}</span>;
+};
+
+export default PresetBadge;

--- a/src/components/SourceList.tsx
+++ b/src/components/SourceList.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useStore } from '../sim/store';
+
+const SourceList: React.FC = () => {
+  const sources = useStore((s) => s.sources);
+  return (
+    <div>
+      <h3>Sources</h3>
+      <ul>
+        {sources.map((s, i) => (
+          <li key={i}>
+            q={s.q.toFixed(2)} x={s.x.toFixed(1)} y={s.y.toFixed(1)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SourceList;

--- a/src/glsl/grad_div.glsl
+++ b/src/glsl/grad_div.glsl
@@ -1,0 +1,1 @@
+void main() {}

--- a/src/glsl/laplace.glsl
+++ b/src/glsl/laplace.glsl
@@ -1,0 +1,2 @@
+// placeholder shader
+void main() {}

--- a/src/glsl/update.glsl
+++ b/src/glsl/update.glsl
@@ -1,0 +1,1 @@
+void main() {}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,12 @@
+html, body, #root {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  font-family: sans-serif;
+  background: #111;
+  color: #eee;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/physics/alpha.ts
+++ b/src/physics/alpha.ts
@@ -1,0 +1,54 @@
+export interface AlphaParams {
+  mu_em: number;
+  mu_s: number;
+  mu_w: number;
+  k1: number;
+  k2: number;
+  k3: number;
+  ag: number;
+  aem: number;
+  as: number;
+  aw: number;
+  G0: number;
+}
+
+export const defaultParams: AlphaParams = {
+  mu_em: 1e10,
+  mu_s: 1e15,
+  mu_w: 1e18,
+  k1: 3,
+  k2: 4,
+  k3: 5,
+  ag: 1e-8,
+  aem: 1 / 137,
+  as: 1.5,
+  aw: 0.05,
+  G0: 0.5,
+};
+
+const sigma = (x: number) => 1 / (1 + Math.exp(-x));
+
+export function alphaU(mu: number, p: AlphaParams = defaultParams): number {
+  const safeMu = Math.max(mu, 1e-30);
+  const term1 = (p.aem - p.ag) * sigma(p.k1 * Math.log(safeMu / p.mu_em));
+  const term2 = (p.as - p.aem) * sigma(p.k2 * Math.log(safeMu / p.mu_s));
+  const sigw = sigma(p.k3 * Math.log(safeMu / p.mu_w));
+  const term3 = p.aw * sigw * Math.exp(-safeMu / p.mu_w);
+  return p.ag + term1 + term2 + term3;
+}
+
+export function alphaUPrime(mu: number, p: AlphaParams = defaultParams): number {
+  const safeMu = Math.max(mu, 1e-30);
+  const l1 = Math.log(safeMu / p.mu_em);
+  const s1 = sigma(p.k1 * l1);
+  const l2 = Math.log(safeMu / p.mu_s);
+  const s2 = sigma(p.k2 * l2);
+  const l3 = Math.log(safeMu / p.mu_w);
+  const s3 = sigma(p.k3 * l3);
+  const dsigma = (k: number, s: number) => k * s * (1 - s) / safeMu;
+  const d1 = (p.aem - p.ag) * dsigma(p.k1, s1);
+  const d2 = (p.as - p.aem) * dsigma(p.k2, s2);
+  const dw =
+    p.aw * (dsigma(p.k3, s3) * Math.exp(-safeMu / p.mu_w) - s3 * Math.exp(-safeMu / p.mu_w) / p.mu_w);
+  return d1 + d2 + dw;
+}

--- a/src/physics/fabric.ts
+++ b/src/physics/fabric.ts
@@ -1,0 +1,48 @@
+import { alphaU, AlphaParams } from './alpha';
+import { clamp } from './units';
+
+export interface Grid {
+  nx: number;
+  ny: number;
+  dx: number;
+  dy: number;
+}
+
+export interface FieldState {
+  phi: Float32Array;
+  phi_t: Float32Array;
+  eps: Float32Array;
+  source: Float32Array;
+}
+
+export function createField(grid: Grid): FieldState {
+  const n = grid.nx * grid.ny;
+  return {
+    phi: new Float32Array(n),
+    phi_t: new Float32Array(n),
+    eps: new Float32Array(n),
+    source: new Float32Array(n),
+  };
+}
+
+export function updateEps(state: FieldState, grid: Grid, params: AlphaParams) {
+  const { phi, eps } = state;
+  const { nx, ny, dx } = grid;
+  const epsSmall = 1e-12;
+  for (let y = 1; y < ny - 1; y++) {
+    for (let x = 1; x < nx - 1; x++) {
+      const i = y * nx + x;
+      const gx = (phi[i + 1] - phi[i - 1]) / (2 * dx);
+      const gy = (phi[i + nx] - phi[i - nx]) / (2 * dx);
+      const grad = Math.hypot(gx, gy);
+      const l = Math.abs(phi[i]) / (grad + epsSmall);
+      const mu = clamp(1 / l, 1e4, 1e20);
+      eps[i] = alphaU(mu, params);
+    }
+  }
+}
+
+export function cfl(dt: number, grid: Grid, c: number, epsMax: number) {
+  const dim = 2;
+  return (c * Math.sqrt(epsMax) * dt) / (grid.dx * Math.sqrt(dim));
+}

--- a/src/physics/forces.ts
+++ b/src/physics/forces.ts
@@ -1,0 +1,37 @@
+import { alphaU, alphaUPrime, AlphaParams } from './alpha';
+
+export interface Source {
+  x: number;
+  y: number;
+  q: number;
+  m: number;
+  vx: number;
+  vy: number;
+}
+
+export interface ForceResult {
+  fx: number;
+  fy: number;
+  r: number;
+  alpha: number;
+  potential: number;
+}
+
+export function pairwiseForce(a: Source, b: Source, p: AlphaParams): ForceResult {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const r2 = dx * dx + dy * dy;
+  const r = Math.sqrt(r2) + 1e-12;
+  const mu = 1 / r;
+  const alpha = alphaU(mu, p);
+  const dalpha = alphaUPrime(mu, p);
+  const coef = p.G0 * a.q * b.q;
+  const fmag = coef * (alpha / (r2) + dalpha / (r2 * r));
+  return {
+    fx: fmag * (dx / r),
+    fy: fmag * (dy / r),
+    r,
+    alpha,
+    potential: -coef * alpha / r,
+  };
+}

--- a/src/physics/integrators.ts
+++ b/src/physics/integrators.ts
@@ -1,0 +1,24 @@
+import { Source, pairwiseForce } from './forces';
+import { AlphaParams } from './alpha';
+
+export function velocityVerlet(sources: Source[], dt: number, p: AlphaParams) {
+  const forces: { fx: number; fy: number }[] = sources.map(() => ({ fx: 0, fy: 0 }));
+  for (let i = 0; i < sources.length; i++) {
+    for (let j = i + 1; j < sources.length; j++) {
+      const f = pairwiseForce(sources[i], sources[j], p);
+      forces[i].fx += f.fx;
+      forces[i].fy += f.fy;
+      forces[j].fx -= f.fx;
+      forces[j].fy -= f.fy;
+    }
+  }
+  for (let i = 0; i < sources.length; i++) {
+    const s = sources[i];
+    const ax = forces[i].fx / s.m;
+    const ay = forces[i].fy / s.m;
+    s.x += s.vx * dt + 0.5 * ax * dt * dt;
+    s.y += s.vy * dt + 0.5 * ay * dt * dt;
+    s.vx += ax * dt;
+    s.vy += ay * dt;
+  }
+}

--- a/src/physics/pde_cpu.ts
+++ b/src/physics/pde_cpu.ts
@@ -1,0 +1,57 @@
+import { FieldState, Grid } from './fabric';
+
+export interface PDEParams {
+  c: number;
+  gamma: Float32Array; // same size as grid
+  dt: number;
+}
+
+export function createGammaMask(grid: Grid, base: number, rim: number, extra: number) {
+  const n = grid.nx * grid.ny;
+  const g = new Float32Array(n).fill(base);
+  for (let y = 0; y < grid.ny; y++) {
+    for (let x = 0; x < grid.nx; x++) {
+      const i = y * grid.nx + x;
+      const dx = Math.min(x, grid.nx - 1 - x);
+      const dy = Math.min(y, grid.ny - 1 - y);
+      const d = Math.min(dx, dy);
+      if (d < rim) {
+        const t = (rim - d) / rim;
+        g[i] = base + extra * 0.5 * (1 - Math.cos(Math.PI * t));
+      }
+    }
+  }
+  return g;
+}
+
+export function stepField(state: FieldState, grid: Grid, p: PDEParams) {
+  const { phi, phi_t, eps, source } = state;
+  const { nx, ny, dx } = grid;
+  const { c, gamma, dt } = p;
+  const nx1 = nx + 1;
+  const ny1 = ny + 1;
+  const lap = (x: number, y: number) => {
+    const i = y * nx + x;
+    const ip = y * nx + (x + 1);
+    const im = y * nx + (x - 1);
+    const jp = (y + 1) * nx + x;
+    const jm = (y - 1) * nx + x;
+    const ex1 = 0.5 * (eps[i] + eps[ip]);
+    const ex2 = 0.5 * (eps[i] + eps[im]);
+    const ey1 = 0.5 * (eps[i] + eps[jp]);
+    const ey2 = 0.5 * (eps[i] + eps[jm]);
+    return (
+      (ex1 * (phi[ip] - phi[i]) - ex2 * (phi[i] - phi[im]) + ey1 * (phi[jp] - phi[i]) - ey2 * (phi[i] - phi[jm])) /
+      (dx * dx)
+    );
+  };
+  for (let y = 1; y < ny - 1; y++) {
+    for (let x = 1; x < nx - 1; x++) {
+      const i = y * nx + x;
+      const lapv = lap(x, y);
+      const acc = c * c * lapv - gamma[i] * phi_t[i] + source[i];
+      phi_t[i] += acc * dt;
+      phi[i] += phi_t[i] * dt;
+    }
+  }
+}

--- a/src/physics/pde_gl.ts
+++ b/src/physics/pde_gl.ts
@@ -1,0 +1,4 @@
+// Placeholder for WebGL2 solver
+export function initGL() {
+  throw new Error('WebGL2 solver not implemented');
+}

--- a/src/physics/rng.ts
+++ b/src/physics/rng.ts
@@ -1,0 +1,8 @@
+export function mulberry32(seed: number) {
+  return function () {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/src/physics/units.ts
+++ b/src/physics/units.ts
@@ -1,0 +1,4 @@
+export const clamp = (x: number, a: number, b: number) => Math.min(Math.max(x, a), b);
+export function mppToDomain(mpp: number, nx: number, ny: number) {
+  return { width: mpp * nx, height: mpp * ny };
+}

--- a/src/sim/presets.ts
+++ b/src/sim/presets.ts
@@ -1,0 +1,30 @@
+import { AlphaParams, defaultParams } from '../physics/alpha';
+import { Preset } from './store';
+
+export interface PresetConfig {
+  params: Partial<AlphaParams>;
+  grid: { nx: number; ny: number; dx: number; dy: number };
+}
+
+export const presets: Record<Preset, PresetConfig> = {
+  kepler: {
+    params: { ag: 1e-8, aem: 1 / 137, as: 1.5, aw: 0.05 },
+    grid: { nx: 64, ny: 64, dx: 1e7, dy: 1e7 },
+  },
+  atomic: {
+    params: { ag: 1e-8, aem: 1 / 137, as: 1.5, aw: 0.03 },
+    grid: { nx: 64, ny: 64, dx: 1e-10, dy: 1e-10 },
+  },
+  strong: {
+    params: { ag: 1e-8, aem: 1 / 137, as: 1.8, aw: 0.03 },
+    grid: { nx: 64, ny: 64, dx: 1e-15, dy: 1e-15 },
+  },
+  custom: {
+    params: {},
+    grid: { nx: 64, ny: 64, dx: 1, dy: 1 },
+  },
+};
+
+export function buildParams(p: Preset): AlphaParams {
+  return { ...defaultParams, ...presets[p].params } as AlphaParams;
+}

--- a/src/sim/store.ts
+++ b/src/sim/store.ts
@@ -1,0 +1,110 @@
+import { useSyncExternalStore } from 'react';
+import { defaultParams, AlphaParams } from '../physics/alpha';
+import { createField, FieldState, Grid, updateEps } from '../physics/fabric';
+import { createGammaMask, stepField } from '../physics/pde_cpu';
+import { Source } from '../physics/forces';
+import { velocityVerlet } from '../physics/integrators';
+import { presets, buildParams } from './presets';
+
+const worker = new Worker(new URL('../worker/sim.worker.ts', import.meta.url), {
+  type: 'module',
+});
+
+export type Mode = 'pair' | 'field';
+export type Preset = 'kepler' | 'atomic' | 'strong' | 'custom';
+
+interface Frame {
+  width: number;
+  height: number;
+  pixels: Uint8ClampedArray;
+}
+
+interface Diagnostics {
+  fps: number;
+  energy: number;
+}
+
+interface State {
+  mode: Mode;
+  preset: Preset;
+  running: boolean;
+  params: AlphaParams;
+  sources: Source[];
+  frame: Frame;
+  diagnostics: Diagnostics;
+  grid: Grid;
+  field: FieldState;
+  gamma: Float32Array;
+  init: () => void;
+  start: () => void;
+  stop: () => void;
+  setMode: (m: Mode) => void;
+  applyPreset: (p: Preset) => void;
+}
+
+const listeners = new Set<() => void>();
+
+const state: State = {
+  mode: 'pair',
+  preset: 'kepler',
+  running: false,
+  params: defaultParams,
+  sources: [],
+  frame: { width: 256, height: 256, pixels: new Uint8ClampedArray(256 * 256 * 4) },
+  diagnostics: { fps: 0, energy: 0 },
+  grid: { nx: 64, ny: 64, dx: 1, dy: 1 },
+  field: createField({ nx: 64, ny: 64, dx: 1, dy: 1 }),
+  gamma: createGammaMask({ nx: 64, ny: 64, dx: 1, dy: 1 }, 0, 8, 0.1),
+  init() {
+    worker.postMessage({ type: 'init', grid: state.grid, params: state.params, mode: state.mode });
+    updateEps(state.field, state.grid, state.params);
+  },
+  start() {
+    state.running = true;
+    worker.postMessage({ type: 'start' });
+    emit();
+  },
+  stop() {
+    state.running = false;
+    worker.postMessage({ type: 'stop' });
+    emit();
+  },
+  setMode(m: Mode) {
+    state.mode = m;
+    worker.postMessage({ type: 'init', grid: state.grid, params: state.params, mode: state.mode });
+    emit();
+  },
+  applyPreset(p: Preset) {
+    state.preset = p;
+    state.params = buildParams(p);
+    const grid = presets[p].grid;
+    state.grid = grid;
+    state.field = createField(grid);
+    state.gamma = createGammaMask(grid, 0, 8, 0.1);
+    updateEps(state.field, state.grid, state.params);
+    worker.postMessage({ type: 'init', grid: state.grid, params: state.params, mode: state.mode });
+    emit();
+  },
+};
+
+function emit() {
+  listeners.forEach((l) => l());
+}
+
+worker.onmessage = (e: MessageEvent<any>) => {
+  const m = e.data;
+  if (m.type === 'frame') {
+    state.frame = { width: m.width, height: m.height, pixels: m.pixels };
+    emit();
+  }
+};
+
+export function useStore<T>(selector: (s: State) => T): T {
+  return useSyncExternalStore(
+    (cb) => {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+    () => selector(state),
+  );
+}

--- a/src/worker/sim.worker.ts
+++ b/src/worker/sim.worker.ts
@@ -1,0 +1,68 @@
+import { alphaU, AlphaParams, defaultParams } from '../physics/alpha';
+import { createField, Grid, updateEps } from '../physics/fabric';
+import { createGammaMask, stepField } from '../physics/pde_cpu';
+import { velocityVerlet } from '../physics/integrators';
+import { Source } from '../physics/forces';
+
+interface InitMsg {
+  type: 'init';
+  grid: Grid;
+  params: AlphaParams;
+  mode: 'pair' | 'field';
+}
+interface StartMsg { type: 'start'; }
+interface StopMsg { type: 'stop'; }
+interface StepMsg { type: 'step'; dt: number; }
+
+type Msg = InitMsg | StartMsg | StopMsg | StepMsg;
+
+let running = false;
+let grid: Grid = { nx: 64, ny: 64, dx: 1, dy: 1 };
+let params: AlphaParams = defaultParams;
+let field = createField(grid);
+let gamma = createGammaMask(grid, 0, 8, 0.1);
+let mode: 'pair' | 'field' = 'field';
+const sources: Source[] = [];
+
+function step(dt: number) {
+  if (mode === 'pair') {
+    velocityVerlet(sources, dt, params);
+  } else {
+    stepField(field, grid, { c: 1, gamma, dt });
+    updateEps(field, grid, params);
+  }
+  const pixels = new Uint8ClampedArray(grid.nx * grid.ny * 4);
+  for (let i = 0; i < grid.nx * grid.ny; i++) {
+    const v = field.phi[i] * 255 + 128;
+    pixels[i * 4 + 0] = v;
+    pixels[i * 4 + 1] = v;
+    pixels[i * 4 + 2] = v;
+    pixels[i * 4 + 3] = 255;
+  }
+  (self as any).postMessage({ type: 'frame', width: grid.nx, height: grid.ny, pixels });
+}
+
+function loop() {
+  if (!running) return;
+  step(0.01);
+  setTimeout(loop, 16);
+}
+
+(self as any).onmessage = (e: MessageEvent<Msg>) => {
+  const m = e.data;
+  if (m.type === 'init') {
+    grid = m.grid;
+    params = m.params;
+    mode = m.mode;
+    field = createField(grid);
+    gamma = createGammaMask(grid, 0, 8, 0.1);
+    updateEps(field, grid, params);
+  } else if (m.type === 'start') {
+    running = true;
+    loop();
+  } else if (m.type === 'stop') {
+    running = false;
+  } else if (m.type === 'step') {
+    step(m.dt);
+  }
+};

--- a/tests/alpha.test.ts
+++ b/tests/alpha.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { alphaU, alphaUPrime, defaultParams } from '../src/physics/alpha';
+
+describe('alphaU', () => {
+  it('approaches plateaus', () => {
+    const p = { ...defaultParams };
+    const low = alphaU(1e5, p);
+    const mid = alphaU(1e12, p);
+    const high = alphaU(1e19, p);
+    expect(low).toBeCloseTo(p.ag, 5);
+    expect(mid).toBeGreaterThan(low);
+    expect(high).toBeLessThanOrEqual(p.as + p.aw);
+  });
+  it('derivative finite', () => {
+    const d = alphaUPrime(1e10, defaultParams);
+    expect(Number.isFinite(d)).toBe(true);
+  });
+});

--- a/tests/forces.test.ts
+++ b/tests/forces.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { pairwiseForce, Source } from '../src/physics/forces';
+import { AlphaParams } from '../src/physics/alpha';
+
+describe('forces', () => {
+  it('reduces to inverse square when unified off', () => {
+    const params: AlphaParams = {
+      mu_em: 1,
+      mu_s: 1,
+      mu_w: 1,
+      k1: 0,
+      k2: 0,
+      k3: 0,
+      ag: 0.1,
+      aem: 0.1,
+      as: 0.1,
+      aw: 0,
+      G0: 1,
+    };
+    const a: Source = { x: 0, y: 0, q: 1, m: 1, vx: 0, vy: 0 };
+    const b: Source = { x: 1, y: 0, q: 1, m: 1, vx: 0, vy: 0 };
+    const f = pairwiseForce(a, b, params);
+    expect(f.fx).toBeCloseTo(0.1, 4); // alpha/r^2 = 0.1
+    expect(Math.abs(f.fy)).toBeLessThan(1e-6);
+  });
+});

--- a/tests/pde.test.ts
+++ b/tests/pde.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { createField, Grid } from '../src/physics/fabric';
+import { stepField, createGammaMask } from '../src/physics/pde_cpu';
+
+function energy(field: Float32Array, phi_t: Float32Array, grid: Grid, c: number) {
+  const { nx, ny, dx } = grid;
+  let e = 0;
+  for (let y = 1; y < ny - 1; y++) {
+    for (let x = 1; x < nx - 1; x++) {
+      const i = y * nx + x;
+      const gx = (field[i + 1] - field[i - 1]) / (2 * dx);
+      const gy = (field[i + nx] - field[i - nx]) / (2 * dx);
+      e += 0.5 * phi_t[i] * phi_t[i] + 0.5 * c * c * (gx * gx + gy * gy);
+    }
+  }
+  return e;
+}
+
+describe('pde_cpu', () => {
+  it('damps energy', () => {
+    const grid: Grid = { nx: 16, ny: 16, dx: 1, dy: 1 };
+    const state = createField(grid);
+    for (let i = 0; i < state.phi.length; i++) state.phi[i] = Math.random() * 0.01;
+    const gamma = createGammaMask(grid, 0.1, 0, 0);
+    const params = { c: 1, gamma, dt: 0.1 };
+    const e0 = energy(state.phi, state.phi_t, grid, params.c);
+    for (let n = 0; n < 10; n++) stepField(state, grid, params);
+    const e1 = energy(state.phi, state.phi_t, grid, params.c);
+    expect(e1).toBeLessThan(e0);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["vitest"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src", "tests", "vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize Vite + React + TS project for GUWT simulator
- implement unified coupling, pairwise forces, CPU PDE solver, and worker-driven simulation loop
- add basic UI components, presets, and tests with CI workflow

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing @eslint/js)*
- `npm run build` *(fails: cannot find type definition file for 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_68954aebdd34832abadbb90c861b1c95